### PR TITLE
0.2.1: height={nil} works, and the README stops arguing against Leaflet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-08-06
+
+### Fixed
+
+- **`height={nil}` is now legal, and actually works.** `attr :height, :string`
+  rejected the `nil` its own documentation recommended — a compile warning, so an
+  error in any project building with `--warnings-as-errors`. It is `:any` now, like
+  `:class`. The attribute is also genuinely omitted rather than rendered as
+  `style=""`, because an empty inline style still beats a class in the cascade: a
+  map sized by `class="h-96"` or by a flex parent could not be sized at all.
+  A `style` you pass yourself now takes precedence over `height`.
+
+### Changed
+
+- The README's opening argument no longer rests on a comparison with another
+  library. It answers the question a Phoenix developer actually faces — "why not
+  just write a hook?" — and Leaflet's name has moved to a **Coming from a Leaflet
+  hook** section, where it is a migration table rather than a benchmark. That
+  section also names the three things that catch people: markers need a stable
+  `:id`, `height` beats your class, and stroke opacity goes through `rgba()`.
+
 ## [0.2.0] - 2026-08-06
 
 Everything the README called "the obvious next steps", minus clustering.
@@ -148,5 +169,6 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
+[0.2.1]: https://github.com/nseaSeb/rover/releases/tag/v0.2.1
 [0.2.0]: https://github.com/nseaSeb/rover/releases/tag/v0.2.0
 [0.1.0]: https://github.com/nseaSeb/rover/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -27,13 +27,29 @@ assign(socket,
 That is the whole thing. Assign a list of maps, get a map. Assign a different
 list, and Rover updates only the markers that actually changed.
 
-## Why not just use Leaflet?
+## Why not just write a hook?
 
-Leaflet is easy and OpenLayers is capable, and most Elixir apps end up picking
-easy. Rover is a bet that you should not have to choose: the ergonomics of a
-Leaflet wrapper, on top of the engine that handles projections, huge vector
-layers, WMS/WMTS, and the rest of the serious GIS surface — so the day your
-"three pins" turn into a cadastral overlay, you are not rewriting.
+Because you already can, and the first version is genuinely short. Three pins on
+a tile layer is a dozen lines of JavaScript and an afternoon.
+
+The afternoon after that is the one to think about. A `phx-hook` has no opinion
+about what happens when the list changes, so you write the reconciliation — and
+if you write the obvious version, clearing the layer and redrawing it, you also
+get the flicker, the interrupted pan and the popup that closes itself. Then the
+framing, because someone will open a map with one marker and another with two
+hundred. Then `updated()`, or you discover that changing the element's `id` is
+the only way to get new data in. Then the coordinate order, once, in the wrong
+direction. Then the attribution, which is a licence condition rather than a
+detail.
+
+None of that is hard. All of it is work you have done before, and Rover has done
+it here, with tests that assert the reconciliation by object identity so it stays
+done.
+
+The other half of the bet is the engine underneath. OpenLayers carries
+projections, huge vector layers, WMS/WMTS and the rest of the serious GIS
+surface — so the day your three pins turn into a cadastral overlay, the ceiling
+is somewhere else entirely.
 
 ## Installation
 
@@ -190,7 +206,7 @@ which is why clustering rather than popups is the answer to hundreds.
 
 ## Coordinates are always `{lat, lon}`
 
-The order you say out loud, and the order Leaflet uses. OpenLayers works in
+The order you say out loud. OpenLayers works in
 `[x, y]` — that is, `[lon, lat]` projected to Web Mercator — and Rover does that
 flip once, in JavaScript, where you never see it.
 
@@ -289,6 +305,35 @@ of static geometry. When it bites, the answer is an `ol/source/Vector` with a UR
 and a revision — not a bigger attribute.
 
 Issues and PRs welcome.
+
+## Coming from a Leaflet hook
+
+Most of the migration is deleting JavaScript. The mapping:
+
+| In your hook | In Rover |
+|---|---|
+| `L.map` + `setView` | `<.map center={{lat, lon}} zoom={12}>` |
+| `L.tileLayer(url, …)` | `tiles={:osm}` or `{:xyz, url, attributions: …}` |
+| `L.marker` + `L.divIcon` with an emoji | a marker's `:emoji` |
+| `L.marker` + an image icon | a marker's `:icon` |
+| `bindPopup(html)` | the `<:popup>` slot — and HEEx escapes it for you |
+| `bindTooltip` / `title` | a marker's `:tooltip` |
+| `L.geoJSON(geometry, style)` | `shapes` with `:color`, `:width`, `:fill_opacity` |
+| `featureGroup().getBounds()` + `fitBounds` | automatic, over markers and shapes together |
+| `handleEvent` + `push_event` to feed the map | `assign/3`; the data rides on attributes |
+| a versioned element `id` to force a remount | not needed — Rover has an `updated()` |
+
+Three things that catch people:
+
+1. **Every marker needs a stable `:id`.** Hook code usually builds anonymous
+   marker maps, because Leaflet has no use for an identity. Rover diffs on it, so
+   without one you get remove-and-add instead of an update — the flicker you were
+   trying to leave behind. Ids are almost always right there in the record you
+   are mapping over.
+2. **`height` is an inline style, and beats your class.** If you size maps with
+   `class="h-96"` or a flex parent, pass `height={nil}`.
+3. **Stroke opacity has no named field.** Leaflet's `opacity: 0.8` on a line
+   becomes `color: "rgba(37, 99, 235, 0.8)"`; `:fill_opacity` covers the fill.
 
 ## Licence
 

--- a/lib/rover/components.ex
+++ b/lib/rover/components.ex
@@ -178,7 +178,19 @@ defmodule Rover.Components do
     default: nil,
     doc: "`@myself` to route events to the enclosing `Phoenix.LiveComponent`."
 
-  attr :height, :string, default: "24rem", doc: "CSS height. Set to nil to style it yourself."
+  # `:any`, not `:string`: the documented escape hatch is `height={nil}`, and a
+  # literal nil against a `:string` attr is a compile warning — an error in any
+  # project building with --warnings-as-errors. `:class` is `:any` for the same
+  # reason.
+  attr :height, :any,
+    default: "24rem",
+    doc: """
+    CSS height, applied as an inline style. Pass `nil` to emit no style at all and
+    size the map from your own CSS — a Tailwind class, a flex parent, a container
+    query. Note that an inline style beats a class, so `class="h-96"` needs
+    `height={nil}` to take effect.
+    """
+
   attr :class, :any, default: nil, doc: "Extra classes on the map container."
   attr :rest, :global
 
@@ -219,12 +231,12 @@ defmodule Rover.Components do
     <div
       id={@id}
       class={classes(@class)}
-      style={@height && "height: #{@height};"}
       phx-hook="Rover"
       data-rover={@config_json}
       data-rover-markers={@markers_json}
       data-rover-shapes={@shapes_json}
       {@rest}
+      {height_style(@height)}
     >
       <div id={"#{@id}-canvas"} class="rover-map__canvas" phx-update="ignore"></div>
       <div
@@ -239,6 +251,14 @@ defmodule Rover.Components do
     </div>
     """
   end
+
+  # As a dynamic attribute rather than `style={...}`: HEEx renders a nil value as
+  # `style=""`, and an empty inline style still wins over a class in the cascade,
+  # so `height={nil}` has to leave the attribute out altogether. Placed after
+  # `{@rest}` because HEEx keeps the first of two identical attribute names, and a
+  # caller who passes their own `style` should win.
+  defp height_style(nil), do: %{}
+  defp height_style(height), do: %{"style" => "height: #{height};"}
 
   # A list containing `nil` renders as a trailing space, which then shows up in
   # every consumer's DOM. Filter before handing it to HEEx.

--- a/lib/rover/geo.ex
+++ b/lib/rover/geo.ex
@@ -3,7 +3,7 @@ defmodule Rover.Geo do
   Coordinate handling for Rover.
 
   Rover speaks **`{latitude, longitude}`** everywhere — the order humans use when
-  they read a coordinate out loud, and the order Leaflet uses. OpenLayers works
+  they read a coordinate out loud. OpenLayers works
   internally in `[x, y]` (i.e. `[longitude, latitude]`) projected to Web
   Mercator; that flip happens once, in the JavaScript runtime, and never leaks
   into your application code.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rover.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @source_url "https://github.com/nseaSeb/rover"
 
   def project do

--- a/test/rover/components_test.exs
+++ b/test/rover/components_test.exs
@@ -63,6 +63,24 @@ defmodule Rover.ComponentsTest do
       assert attribute(document, "class") == "rover-map shadow-lg"
     end
 
+    test "height={nil} emits no style, leaving the size to the caller's CSS" do
+      # The documented escape hatch. It has to be a legal literal: an inline style
+      # beats a Tailwind class, so a map sized by `class` or by a flex parent needs
+      # this, and `attr :height, :string` made it a compile warning.
+      document = render_map(height: nil, class: "h-96")
+
+      # Absent, not empty: `style=""` is still an inline style, and an inline style
+      # beats a class even when it says nothing.
+      assert attribute(document, "style") == nil
+      assert attribute(document, "class") == "rover-map h-96"
+    end
+
+    test "a caller's own style wins over the height" do
+      document = render_map(height: "24rem", style: "height: 40vh; border: 0;")
+
+      assert attribute(document, "style") == "height: 40vh; border: 0;"
+    end
+
     test "emits no stray whitespace when no class was given" do
       assert attribute(render_map([]), "class") == "rover-map"
     end


### PR DESCRIPTION
Two things surfaced by using 0.2.0 in a real application.

## `height={nil}` was documented but illegal — and then still broken

`attr :height, :string` rejected the `nil` its own doc recommended. Phoenix emits `attribute "height" ... must be a :string, got: nil` — a compile warning, so an **error** in any project building with `--warnings-as-errors`. Now `:any`, like `:class` always was.

Fixing the type was not enough. `style={@height && …}` renders `style=""` for a nil value instead of omitting the attribute, and an empty inline style still beats a class in the cascade — so a map sized by `class="h-96"` or by a flex parent could not be sized at all, which is exactly the case the escape hatch exists for. The style is now a dynamic attribute, genuinely absent when there is no height, and placed after `{@rest}` so a caller's own `style` wins.

Three tests: `height={nil}` emits no `style`, a caller's `style` overrides, and the existing height/class case still holds.

## The README stopped resting on someone else's library

The opening section was titled "Why not just use Leaflet?" and made a third-party project the yardstick for this one — while answering a question a Phoenix developer does not actually ask. The question in front of them is **"why not just write a hook?"**, and that has the better answer: the first afternoon is short; the ones after it are the reconciliation, the framing, `updated()`, the coordinate order and the attribution.

Leaflet's name moves to **Coming from a Leaflet hook** — a migration table rather than a benchmark, which serves the people most likely to arrive here. It names the three things that catch them: markers need a stable `:id`, `height` beats your class, stroke opacity goes through `rgba()`.

The two remaining mentions in the JavaScript stay; one of them explains why `resolveRetina` exists at all.

131 Elixir tests, 48 Node tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)