### PR TITLE
The bring-your-own-OpenLayers path has never built, and the guard that would have caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           # the declared requirement is wrong — do not just drop the row.
           - elixir: "1.15.8"
             otp: "26.2"
+          - elixir: "1.16.3"
+            otp: "26.2"
           - elixir: "1.17.3"
             otp: "27.2"
           - elixir: "1.18.4"
@@ -166,7 +168,7 @@ jobs:
 
       # Everything below the component — the canvas, the popup DOM, the tile URLs
       # the browser actually requests — lives where ExUnit and node --test cannot
-      # look. Both rendering bugs this library has shipped were in here.
+      # look. Every rendering bug this library has shipped was in here.
       # `mix dev` is started by Playwright's webServer, which also runs the esbuild
       # watcher, so the bundle under test is built from the current source.
       - run: npm run test:browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A smoke test over the bundles in `priv/static`** (`assets/test/bundles.test.js`).
+  Nothing exercised what Hex actually ships: the playground and the browser suite
+  both import `assets/js/index.js`, and the CI `bundles` job only runs
+  `git diff --quiet -- priv/static`, which proves the artefacts match the source
+  and not that they load. The new test loads `rover.js` and `rover.min.js` and
+  checks the export surface, the hook's LiveView callbacks and a `project` /
+  `unproject` round trip; `rover.external.js` cannot be imported from
+  `priv/static` — it leaves `ol` as a peer import and there is no `node_modules`
+  above it — so it is checked as text instead.
+- Elixir 1.16.3 in the CI matrix. It sits inside the `~> 1.15` requirement and
+  was the one version in range that nothing tested.
+
+### Fixed
+
+- **The bring-your-own-OpenLayers instructions did not build.** Following them
+  as written stops esbuild with `Could not resolve "ol/Map.js"`, once per each
+  of the twenty-seven `ol` specifiers the peer build leaves bare. esbuild
+  resolves a bare import by walking up from the file that wrote it —
+  `deps/rover/priv/static/`, where no `node_modules` exists — and Phoenix's
+  generated `NODE_PATH` covers `deps` only, never `assets/node_modules`. Both
+  the README and the `Rover` moduledoc now carry the `config/config.exs` change
+  that puts `ol` on the search path. Reproduced against esbuild 0.25.12 with
+  Phoenix's own `cd` and `NODE_PATH`, and confirmed fixed the same way.
+- **The installation example in the `Rover` moduledoc still read
+  `{:rover, "~> 0.2"}`.** 0.3.1 fixed the README copy and missed this one, which
+  is the snippet HexDocs renders on the module page.
+- `mix precommit` ran `assets.test` before `assets.build`, so the new bundle
+  smoke test would have checked the artefacts from the previous run and let the
+  ones about to be committed through untested.
+- The changelog had no link definitions for `[0.3.0]` and `[0.3.1]`, so both
+  headings rendered as literal brackets.
+- The comment explaining why `setContent` fits once was attached to
+  `setHeatmap`, the method above it.
+
 ## [0.3.1] - 2026-08-08
 
 ### Fixed
@@ -15,8 +53,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   later cell, so it collided with `Kino.JS.Live.Context`'s own `assign/2` in
   `RoverKino`. The import now lives inside its own module, scoped to the cell
   that needs it.
-- The installation example still read `{:rover, "~> 0.2"}`, which would not
-  have resolved to 0.3.0 or this release on a fresh install.
+- The installation example in the README still read `{:rover, "~> 0.2"}`, one
+  series behind what it was installing. The same copy in the `Rover` moduledoc
+  was missed; see Unreleased.
 
 ## [0.3.0] - 2026-08-07
 
@@ -263,5 +302,7 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
+[0.3.1]: https://github.com/nseaSeb/rover/releases/tag/v0.3.1
+[0.3.0]: https://github.com/nseaSeb/rover/releases/tag/v0.3.0
 [0.2.0]: https://github.com/nseaSeb/rover/releases/tag/v0.2.0
 [0.1.0]: https://github.com/nseaSeb/rover/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -371,9 +371,31 @@ map.contentExtent
 If you already build with `npm` and want to own the `ol` version:
 
 ```js
-// package.json: "ol": "^10.0.0"
+// assets/package.json: "ol": "^10.0.0"
 import { RoverHooks } from "../../deps/rover/priv/static/rover.external.js"
 ```
+
+This one needs a build change, and without it esbuild stops with `Could not
+resolve "ol/Map.js"` — once for each of the twenty-seven `ol` specifiers the
+peer build leaves bare. esbuild resolves a bare import by walking up from the
+file that wrote it, which here is `deps/rover/priv/static/`, where there is no
+`node_modules` and never will be. Phoenix's generated `NODE_PATH` points at
+`deps` alone, so your `ol` is never on the search path.
+
+In your existing `config :esbuild` block in `config/config.exs`, replace the
+`env:` key — leave `args:` and `cd:` exactly as they are:
+
+```elixir
+env: %{
+  "NODE_PATH" =>
+    Enum.join(
+      [Path.expand("../deps", __DIR__), Path.expand("../assets/node_modules", __DIR__)],
+      if(match?({:win32, _}, :os.type()), do: ";", else: ":")
+    )
+}
+```
+
+The default build needs none of this — OpenLayers is already inside `rover.js`.
 
 ## Try it without installing anything
 
@@ -396,8 +418,8 @@ mix assets.test.browser   # the browser suite, in a real Chromium
 
 The browser suite is small on purpose. Everything below the component — the
 canvas, the popup DOM, the tile URLs the browser actually requests — lives where
-ExUnit and `node --test` cannot look, and both rendering bugs this library has
-shipped were in there. It stands guard over those paths and nothing else. Each
+ExUnit and `node --test` cannot look, and every rendering bug this library has
+shipped was in there. It stands guard over those paths and nothing else. Each
 scenario has been watched to fail with its bug reintroduced.
 
 The playground (`dev/demo_live.ex`) is the reference for the intended

--- a/assets/js/rover_map.js
+++ b/assets/js/rover_map.js
@@ -84,6 +84,11 @@ export class RoverMap {
     this.maybeFit()
   }
 
+  setHeatmap(heatmap) {
+    this.heatmapLayer.reconcile(heatmap)
+    this.maybeFit()
+  }
+
   /**
    * Load both layers and fit once.
    *
@@ -93,11 +98,6 @@ export class RoverMap {
    * outside the shapes' bounding box was simply off-screen, for good. The mount
    * path and any update touching both layers go through here instead.
    */
-  setHeatmap(heatmap) {
-    this.heatmapLayer.reconcile(heatmap)
-    this.maybeFit()
-  }
-
   setContent({ markers, shapes, heatmap }) {
     if (heatmap !== undefined) this.heatmapLayer.reconcile(heatmap)
     if (shapes !== undefined) this.shapeLayer.reconcile(shapes)

--- a/assets/test/bundles.test.js
+++ b/assets/test/bundles.test.js
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { describe, it } from "node:test"
+
+// Everything else in this suite imports `../js/`, and so do the playground
+// (`dev/assets/app.js`) and the Playwright suite behind it. Nothing exercises
+// what Hex actually ships. The CI `bundles` job only runs `git diff --quiet --
+// priv/static`, which proves the bundles match the source, not that they work:
+// a pattern esbuild resolves or minifies differently ships green.
+//
+// This is the smallest guard that closes that gap. It loads the published
+// artefacts the way a consumer does and checks the contract they promise.
+
+// The public API. A change here is a change to the README's install snippet and
+// to every consumer's import — it should be deliberate, so it is written out
+// rather than derived from the source.
+const CONTRACT = [
+  "HeatmapLayer",
+  "MarkerLayer",
+  "Rover",
+  "RoverHooks",
+  "RoverMap",
+  "ShapeLayer",
+  "default",
+  "extentToBbox",
+  "project",
+  "unproject",
+]
+
+// The two self-contained builds: OpenLayers is inside, so they load from
+// anywhere, which is the whole point of the no-npm install path.
+const SELF_CONTAINED = ["rover.js", "rover.min.js"]
+
+// Loaded through a data: URL rather than by path, which forces ESM outright.
+// Importing priv/static by path makes Node look for the nearest ancestor
+// package.json to decide the module type — and there is none inside the repo,
+// so it walks out of it. Here that lands on a file in $HOME; on a contributor
+// whose home or monorepo root declares `"type": "commonjs"` it would fail with
+// `Cannot use import statement outside a module`, in a suite unrelated to
+// whatever they were changing. A consumer never meets this — esbuild and Vite
+// decide format from the import site, not from a package.json above the file.
+const load = (name) => {
+  const source = readFileSync(new URL(`../../priv/static/${name}`, import.meta.url))
+  return import(`data:text/javascript;base64,${source.toString("base64")}`)
+}
+
+for (const name of SELF_CONTAINED) {
+  describe(`priv/static/${name}`, () => {
+    it("exports exactly the documented surface", async () => {
+      const bundle = await load(name)
+
+      assert.deepEqual(Object.keys(bundle).sort(), CONTRACT)
+    })
+
+    it("carries a hook with the LiveView callbacks", async () => {
+      const { Rover, RoverHooks, default: fallback } = await load(name)
+
+      // Minification renames locals, never object keys — but LiveView looks
+      // `mounted` and friends up by name, so a build that mangled them would
+      // fail in a consumer's app and nowhere else.
+      for (const callback of ["mounted", "updated", "destroyed"]) {
+        assert.equal(typeof Rover[callback], "function", `Rover.${callback}`)
+      }
+
+      assert.equal(RoverHooks.Rover, Rover)
+      assert.equal(fallback.Rover, Rover)
+    })
+
+    it("exports coordinate helpers that actually run", async () => {
+      const { project, unproject } = await load(name)
+
+      // Round-tripping Lyon proves the module initialised: `project` reaches
+      // into OpenLayers' projection registry, which an under-bundled build
+      // would leave empty.
+      assert.deepEqual(unproject(project(45.75, 4.85)), { lat: 45.75, lon: 4.85 })
+    })
+  })
+}
+
+// rover.external.js leaves `ol` as a peer import, so Node would resolve those
+// specifiers from priv/static/ — where there is no node_modules and never will
+// be. It is checked as text instead: the export surface, and the fact that the
+// peer imports really did stay peer imports.
+describe("priv/static/rover.external.js", () => {
+  const source = readFileSync(new URL("../../priv/static/rover.external.js", import.meta.url), "utf8")
+
+  it("exports exactly the documented surface", () => {
+    const block = source.match(/export \{([^}]*)\};?\s*$/)
+    assert.ok(block, "no trailing export block")
+
+    const names = block[1]
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map((entry) => (entry.includes(" as ") ? entry.split(" as ")[1].trim() : entry))
+
+    assert.deepEqual(names.sort(), CONTRACT)
+  })
+
+  it("leaves OpenLayers as a peer import", () => {
+    const specifiers = [...source.matchAll(/from "(ol(?:\/[^"]*)?)"/g)].map((match) => match[1])
+
+    // If esbuild ever stopped honouring `external: ["ol", "ol/*"]`, this build
+    // would silently become a second copy of the bundled one — same bytes as
+    // rover.js, 35x the size it advertises.
+    assert.ok(specifiers.length > 0, "no bare ol imports survived")
+    assert.ok(
+      source.length < 200_000,
+      `external build is ${source.length} bytes — OpenLayers looks inlined`,
+    )
+  })
+})

--- a/lib/rover.ex
+++ b/lib/rover.ex
@@ -27,7 +27,7 @@ defmodule Rover do
   Add the dependency:
 
       def deps do
-        [{:rover, "~> 0.2"}]
+        [{:rover, "~> 0.3"}]
       end
 
   Register the hook in `assets/js/app.js`. Rover ships a prebuilt bundle with
@@ -65,8 +65,29 @@ defmodule Rover do
   If your app already builds JavaScript with `npm` and you want to control the
   OpenLayers version, import the peer build instead and add `ol` yourself:
 
-      // package.json: "ol": "^10.0.0"
+      // assets/package.json: "ol": "^10.0.0"
       import { RoverHooks } from "../../deps/rover/priv/static/rover.external.js"
+
+  This one needs a build change, and without it esbuild stops with `Could not
+  resolve "ol/Map.js"` — once for each of the twenty-seven `ol` specifiers the
+  peer build leaves bare. esbuild resolves a bare import by walking up from the
+  file that wrote it, which here is `deps/rover/priv/static/`, where there is no
+  `node_modules` and never will be. Phoenix's generated `NODE_PATH` points at
+  `deps` alone, so your `ol` is never on the search path.
+
+  In your existing `config :esbuild` block in `config/config.exs`, replace the
+  `env:` key — leave `args:` and `cd:` exactly as they are:
+
+      env: %{
+        "NODE_PATH" =>
+          Enum.join(
+            [Path.expand("../deps", __DIR__), Path.expand("../assets/node_modules", __DIR__)],
+            if(match?({:win32, _}, :os.type()), do: ";", else: ":")
+          )
+      }
+
+  The default build needs none of this — OpenLayers is already inside
+  `rover.js`.
 
   Rover is tested against the version it bundles; the peer build is offered for
   applications that need to share a single OpenLayers instance with their own

--- a/mix.exs
+++ b/mix.exs
@@ -66,8 +66,11 @@ defmodule Rover.MixProject do
         "format",
         "compile --warnings-as-errors",
         "test",
-        "assets.test",
-        "assets.build"
+        # Build before testing: `assets/test/bundles.test.js` loads the files in
+        # priv/static, so running it first would check the bundles from the last
+        # run and let the ones about to be committed through untested.
+        "assets.build",
+        "assets.test"
       ]
     ]
   end

--- a/priv/static/rover.external.js
+++ b/priv/static/rover.external.js
@@ -707,6 +707,10 @@ var RoverMap = class {
     this.shapeLayer.reconcile(shapes);
     this.maybeFit();
   }
+  setHeatmap(heatmap) {
+    this.heatmapLayer.reconcile(heatmap);
+    this.maybeFit();
+  }
   /**
    * Load both layers and fit once.
    *
@@ -716,10 +720,6 @@ var RoverMap = class {
    * outside the shapes' bounding box was simply off-screen, for good. The mount
    * path and any update touching both layers go through here instead.
    */
-  setHeatmap(heatmap) {
-    this.heatmapLayer.reconcile(heatmap);
-    this.maybeFit();
-  }
   setContent({ markers, shapes, heatmap }) {
     if (heatmap !== void 0) this.heatmapLayer.reconcile(heatmap);
     if (shapes !== void 0) this.shapeLayer.reconcile(shapes);

--- a/priv/static/rover.js
+++ b/priv/static/rover.js
@@ -40846,6 +40846,10 @@ var RoverMap = class {
     this.shapeLayer.reconcile(shapes);
     this.maybeFit();
   }
+  setHeatmap(heatmap) {
+    this.heatmapLayer.reconcile(heatmap);
+    this.maybeFit();
+  }
   /**
    * Load both layers and fit once.
    *
@@ -40855,10 +40859,6 @@ var RoverMap = class {
    * outside the shapes' bounding box was simply off-screen, for good. The mount
    * path and any update touching both layers go through here instead.
    */
-  setHeatmap(heatmap) {
-    this.heatmapLayer.reconcile(heatmap);
-    this.maybeFit();
-  }
   setContent({ markers, shapes, heatmap }) {
     if (heatmap !== void 0) this.heatmapLayer.reconcile(heatmap);
     if (shapes !== void 0) this.shapeLayer.reconcile(shapes);


### PR DESCRIPTION
## The defect

Following the documented peer-build instructions stops esbuild with `Could not resolve "ol/proj.js"` — once for each of the twenty-seven `ol` specifiers `rover.external.js` leaves bare.

esbuild resolves a bare import by walking up from the file that wrote it. Here that is `deps/rover/priv/static/`, where there is no `node_modules` and never will be, and Phoenix's generated `NODE_PATH` covers `deps` alone — so the application's own `ol` is never on the search path.

Reproduced against esbuild 0.25.12 using Phoenix's own `cd` and `NODE_PATH`, taken from the `phx.new` template, and confirmed fixed by putting `assets/node_modules` on `NODE_PATH`: 27 errors without it, a clean build with. The default path is unaffected — OpenLayers is inlined into `rover.js` — which is why this went unnoticed. **Nothing in CI or either test suite builds a consumer-shaped application.**

The README and the `Rover` moduledoc now carry the same block, character for character. It shows the `env:` key alone rather than a whole `config :esbuild` block, because `phx.new`'s template carries `--external:/fonts/*` and `--external:/images/*` that a copy-pasted full block would silently drop; the path separator comes from `:os.type()` rather than being hardcoded.

## The same drift, one release earlier

The installation snippet in that moduledoc still read `{:rover, "~> 0.2"}`. 0.3.1 fixed the README copy and missed this one — the snippet HexDocs renders on the module page. The 0.3.1 rationale is corrected too: `~> 0.2` *does* resolve to 0.3.1, it was simply a series stale.

## The guard

Nothing exercised `priv/static`. The playground and the Playwright suite both import `assets/js/index.js`, and the CI `bundles` job only runs `git diff --quiet -- priv/static`, which proves the artefacts match the source and not that they load.

`assets/test/bundles.test.js` loads `rover.js` and `rover.min.js` and checks the export surface, the hook's LiveView callbacks, and a `project`/`unproject` round trip that only passes if OpenLayers' projection registry initialised. `rover.external.js` cannot be imported from `priv/static` — same resolution rule as the bug above — so it is checked as text.

The bundles load through a `data:` URL rather than by path. Importing them by path makes Node look for the nearest ancestor `package.json` to decide the module type, and there is none inside the repo, so it walks out; on a contributor whose home or monorepo root declares `"type": "commonjs"` the suite would fail with `Cannot use import statement outside a module`, unrelated to whatever they were changing.

`precommit` ran `assets.test` before `assets.build`, which would have checked the bundles from the previous run and let the ones about to be committed through untested. **Verified by sabotage**, per `AGENTS.md`: commenting out an export in `index.js` turns all three bundle suites red.

Also: Elixir 1.16.3 joins the CI matrix — the one version inside the declared `~> 1.15` range that nothing tested — and the comment explaining why `setContent` fits once is reattached to `setContent` rather than to `setHeatmap` above it.

## Not done

No CI job builds a consumer-shaped application. A fixture app plus an esbuild run in the `bundles` job would have caught this one; left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)