### PR TITLE
Rover 0.3.2: a documented install path that never built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.2] - 2026-08-10
 
 ### Added
 
@@ -302,6 +302,7 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
+[0.3.2]: https://github.com/nseaSeb/rover/releases/tag/v0.3.2
 [0.3.1]: https://github.com/nseaSeb/rover/releases/tag/v0.3.1
 [0.3.0]: https://github.com/nseaSeb/rover/releases/tag/v0.3.0
 [0.2.0]: https://github.com/nseaSeb/rover/releases/tag/v0.2.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rover.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @source_url "https://github.com/nseaSeb/rover"
 
   def project do


### PR DESCRIPTION
Version bump and changelog cut for 0.3.2. The work itself landed in #13.

## What is in it

**The bring-your-own-OpenLayers instructions did not build.** Following them as written stops esbuild with `Could not resolve "ol/Map.js"`, once for each of the twenty-seven `ol` specifiers the peer build leaves bare — esbuild resolves a bare import by walking up from the file that wrote it, and Phoenix's generated `NODE_PATH` never covers `assets/node_modules`. Both the README and the `Rover` moduledoc now carry the `config/config.exs` change that fixes it. The default install path was never affected.

**The installation snippet in the `Rover` moduledoc still read `{:rover, "~> 0.2"}`** — the copy HexDocs renders on the module page. 0.3.1 fixed the README and missed this one.

**A smoke test over the bundles in `priv/static`**, which nothing exercised before: the playground and the browser suite both import the source, and the CI `bundles` job only proves the artefacts match it.

Plus `mix precommit` building before testing those bundles, Elixir 1.16.3 in the CI matrix, and the changelog link definitions for 0.3.0 and 0.3.1 that were missing.

## After merge

Tag `v0.3.2` on `main`, then `mix hex.publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)