### PR TITLE
Support Carto API keys 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Carto API key support** on `:carto_light`, `:carto_dark`, and
+  `:carto_voyager`, which Carto now requires. Configure a default with
+  `config :rover, Rover.Tiles, carto_api_key: "..."`, or pass
+  `tiles={{:carto_dark, key: "..."}}` per call to override it. Presets
+  without a key configured or passed are unaffected. Carto is retiring these
+  raster endpoints for vector tiles; Rover's basemap layer stays raster-only
+  for now.
+
 ## [0.5.0] - 2026-08-31
 
 ### Added
@@ -78,7 +90,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - A `Rover.Shape` fallback clause that could not be reached — every caller of the
   private `get/2` is already inside an `is_map/1` guard. Dialyzer's first find.
-
 ## [0.4.0] - 2026-08-12
 
 ### Added
@@ -398,6 +409,7 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
+[Unreleased]: https://github.com/nseaSeb/rover/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/nseaSeb/rover/releases/tag/v0.5.0
 [0.4.0]: https://github.com/nseaSeb/rover/releases/tag/v0.4.0
 [0.3.2]: https://github.com/nseaSeb/rover/releases/tag/v0.3.2

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,3 +35,7 @@ generally a condition of use, not a courtesy.
 The OpenStreetMap and CARTO presets target public demo endpoints whose usage
 policies forbid production traffic. For anything real, pass `{:xyz, url}` with
 tiles you are entitled to serve.
+
+CARTO also requires an API key on its raster presets (`:carto_light`,
+`:carto_dark`, `:carto_voyager`) and is retiring those raster endpoints in
+favor of vector tiles. See `Rover.Tiles` for how to configure a key.

--- a/README.md
+++ b/README.md
@@ -458,6 +458,23 @@ The OSM and Carto presets point at **public demo servers with usage policies
 that forbid production traffic** — for anything real, point `{:xyz, …}` at tiles
 you are entitled to use.
 
+Carto now requires an API key on `:carto_light`, `:carto_dark`, and
+`:carto_voyager`:
+
+```elixir
+# config.exs — applies to every carto_* preset
+config :rover, Rover.Tiles, carto_api_key: "YOUR_KEY"
+```
+
+```heex
+<%!-- or per call, which overrides the configured default --%>
+<.map id="m" tiles={{:carto_dark, key: "YOUR_KEY"}} ... />
+```
+
+Carto is also retiring these raster endpoints for vector tiles; Rover's
+OpenLayers basemap layer is raster-only today, so treat the Carto presets as a
+transitional option rather than a long-term one.
+
 ## What "only update what changed" actually means
 
 The map is rendered as three attributes: `data-rover` (the view),

--- a/lib/rover/tiles.ex
+++ b/lib/rover/tiles.ex
@@ -15,6 +15,25 @@ defmodule Rover.Tiles do
   that forbid heavy traffic; for anything beyond development, point `{:xyz, …}`
   at tiles you are entitled to use.
 
+  ## Carto API keys
+
+  Carto now requires an API key on `:carto_light`, `:carto_dark`, and
+  `:carto_voyager`, requests without one are rejected. Configure a default for
+  the whole app:
+
+      config :rover, Rover.Tiles, carto_api_key: "YOUR_KEY"
+
+  or pass one per call, which overrides the configured default:
+
+      <.map id="m" tiles={{:carto_dark, key: "YOUR_KEY"}} ... />
+
+  Carto is also retiring these raster tile endpoints in favor of vector tiles
+  (MapLibre-style GL JSON served as MVT). Rover's map renders basemaps through
+  OpenLayers' raster `XYZ` source today, so the presets here stay on raster
+  until Rover grows a vector tile layer — track Carto's deprecation notices if
+  you depend on `:carto_light`, `:carto_dark`, or `:carto_voyager` past their
+  raster sunset date.
+
   ## France
 
   `:ign_plan` and `:ign_ortho` serve the French Géoportail — the reference plan
@@ -103,7 +122,14 @@ defmodule Rover.Tiles do
           | :ign_plan
           | :ign_ortho
 
-  @type t :: preset() | :none | {:xyz, String.t()} | {:xyz, String.t(), keyword()}
+  @type t ::
+          preset()
+          | {preset(), keyword()}
+          | :none
+          | {:xyz, String.t()}
+          | {:xyz, String.t(), keyword()}
+
+  @carto_presets [:carto_light, :carto_dark, :carto_voyager]
 
   @doc """
   The list of available preset names.
@@ -137,10 +163,13 @@ defmodule Rover.Tiles do
   def resolve!(:none), do: nil
   def resolve!(nil), do: nil
 
-  def resolve!(name) when is_atom(name) do
+  def resolve!(name) when is_atom(name), do: resolve!({name, []})
+
+  def resolve!({name, opts}) when is_atom(name) and is_list(opts) do
     case Map.fetch(@presets, name) do
       {:ok, tiles} ->
-        tiles
+        key = Keyword.get(opts, :key, default_key(name))
+        apply_key(tiles, key)
 
       :error ->
         raise ArgumentError, """
@@ -169,7 +198,23 @@ defmodule Rover.Tiles do
     invalid tiles: #{inspect(other)}.
 
     Expected a preset name (#{Enum.map_join(presets(), ", ", &inspect/1)}), `:none`,
-    or `{:xyz, url}` / `{:xyz, url, opts}`.
+    `{preset, opts}`, or `{:xyz, url}` / `{:xyz, url, opts}`.
     """
+  end
+
+  # Only the Carto presets have a configured default — every other preset's
+  # `key` stays nil unless a caller passes one explicitly, so pointing this at
+  # an unkeyed provider is a no-op rather than a broken URL.
+  defp default_key(name) when name in @carto_presets do
+    :rover |> Application.get_env(__MODULE__, []) |> Keyword.get(:carto_api_key)
+  end
+
+  defp default_key(_name), do: nil
+
+  defp apply_key(tiles, nil), do: tiles
+
+  defp apply_key(tiles, key) when is_binary(key) do
+    separator = if String.contains?(tiles.url, "?"), do: "&", else: "?"
+    %{tiles | url: tiles.url <> separator <> "key=" <> URI.encode_www_form(key)}
   end
 end

--- a/test/rover/tiles_test.exs
+++ b/test/rover/tiles_test.exs
@@ -47,4 +47,61 @@ defmodule Rover.TilesTest do
   test "rejects anything else" do
     assert_raise ArgumentError, ~r/invalid tiles/, fn -> Tiles.resolve!("https://x") end
   end
+
+  describe "carto api keys" do
+    setup do
+      previous = Application.get_env(:rover, Tiles)
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:rover, Tiles, previous)
+        else
+          Application.delete_env(:rover, Tiles)
+        end
+      end)
+    end
+
+    test "with no key configured, the carto url is unchanged" do
+      Application.delete_env(:rover, Tiles)
+
+      assert Tiles.resolve!(:carto_dark).url ==
+               "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+    end
+
+    test "a configured default key is appended to every carto preset" do
+      Application.put_env(:rover, Tiles, carto_api_key: "configured-key")
+
+      for preset <- [:carto_light, :carto_dark, :carto_voyager] do
+        assert Tiles.resolve!(preset).url =~ "?key=configured-key"
+      end
+    end
+
+    test "a per-call key overrides the configured default" do
+      Application.put_env(:rover, Tiles, carto_api_key: "configured-key")
+
+      resolved = Tiles.resolve!({:carto_voyager, key: "call-key"})
+
+      assert resolved.url =~ "?key=call-key"
+      refute resolved.url =~ "configured-key"
+    end
+
+    test "a non-carto preset is left alone by the configured default" do
+      Application.put_env(:rover, Tiles, carto_api_key: "configured-key")
+
+      refute Tiles.resolve!(:osm).url =~ "key="
+    end
+
+    test "a key on a preset whose url already has a query string joins with &" do
+      resolved = Tiles.resolve!({:ign_plan, key: "some-key"})
+
+      assert resolved.url =~ "&key=some-key"
+      refute resolved.url =~ "?key=some-key"
+    end
+
+    test "the key is url-encoded" do
+      resolved = Tiles.resolve!({:carto_light, key: "a key/with+specials"})
+
+      assert resolved.url =~ "key=a+key%2Fwith%2Bspecials"
+    end
+  end
 end


### PR DESCRIPTION
Carto now needs an api key on  requests to its raster basemap endpoints: https://carto.com/basemaps/apikey/

Tile presets can carry a key via {preset, key: ...}, and carto_* presets
fall back to an app-config default (carto_api_key), so most callers
just set it once. Presets with no key configured or passed keep their
plain URL.

I have another branch on top of this one to support carto vector basemaps, once this lands I will it 😄 