### PR TITLE
Rover 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-08-31
 
 ### Added
 
@@ -409,7 +409,7 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
-[Unreleased]: https://github.com/nseaSeb/rover/compare/v0.5.0...HEAD
+[0.6.0]: https://github.com/nseaSeb/rover/releases/tag/v0.6.0
 [0.5.0]: https://github.com/nseaSeb/rover/releases/tag/v0.5.0
 [0.4.0]: https://github.com/nseaSeb/rover/releases/tag/v0.4.0
 [0.3.2]: https://github.com/nseaSeb/rover/releases/tag/v0.3.2

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ is somewhere else entirely.
 
 ```elixir
 def deps do
-  [{:rover, "~> 0.5"}]
+  [{:rover, "~> 0.6"}]
 end
 ```
 

--- a/lib/rover.ex
+++ b/lib/rover.ex
@@ -27,7 +27,7 @@ defmodule Rover do
   Add the dependency:
 
       def deps do
-        [{:rover, "~> 0.5"}]
+        [{:rover, "~> 0.6"}]
       end
 
   Register the hook in `assets/js/app.js`. Rover ships a prebuilt bundle with

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rover.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
   @source_url "https://github.com/nseaSeb/rover"
 
   def project do


### PR DESCRIPTION
Cuts the changelog and bumps the version for Carto API key support (#17), which landed after 0.5.0 was tagged.

## Why 0.6.0 rather than publishing 0.5.0 first

0.5.0 was tagged this morning and never published to Hex. Publishing it would have shipped a release in which `:carto_light`, `:carto_dark` and `:carto_voyager` are broken — Carto now rejects requests to its raster endpoints without a key. The fix goes out instead of waiting behind it.

The 0.5.0 changelog section stays where it is and its tag stays on GitHub; Hex goes from 0.4.0 straight to 0.6.0, and the changelog documents both.

## Why minor rather than patch

`{preset, opts}` is a new accepted form of the `tiles` attribute, and `config :rover, Rover.Tiles, carto_api_key:` is new configuration. That is added public surface, not a repair of existing behaviour.

## Verification

`mix precommit` (31 doctests, 211 tests, 103 Node tests, 0 failures), `mix dialyzer` 0 errors, `npm run test:browser` 28 scenarios, coverage 95.85% against the 95% floor, `priv/static` in sync, `mix docs` clean.

Both `{:rover, "~> 0.6"}` snippets updated — the README's and the `Rover` moduledoc copy that HexDocs renders on the module page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UexYXBcqg5F5JaQAJ9HhjY