### PR TITLE
One release, 0.5.0 — and Carto's key requirement, corrected against the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,6 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2026-08-31
-
-### Added
-
-- **Carto API key support** on `:carto_light`, `:carto_dark`, and
-  `:carto_voyager`, which Carto now requires. Configure a default with
-  `config :rover, Rover.Tiles, carto_api_key: "..."`, or pass
-  `tiles={{:carto_dark, key: "..."}}` per call to override it. Presets
-  without a key configured or passed are unaffected. Carto is retiring these
-  raster endpoints for vector tiles; Rover's basemap layer stays raster-only
-  for now.
-
 ## [0.5.0] - 2026-08-31
 
 ### Added
@@ -76,6 +64,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   only `data-*` attributes onto one of those — a map that locked itself would
   otherwise stay a focusable `role="application"` with nothing behind it.
 
+- **Carto API key support** on `:carto_light`, `:carto_dark`, and
+  `:carto_voyager`, which Carto's basemaps now need. Configure a default with
+  `config :rover, Rover.Tiles, carto_api_key: "..."`, or pass
+  `tiles={{:carto_dark, key: "..."}}` per call to override it. A preset with no
+  key configured or passed keeps the URL it had.
+
+  Worth knowing what an unkeyed map looks like, because it is not what anyone
+  goes looking for: the tiles still load, with `API KEY REQUIRED` stamped
+  diagonally across every one. Not a blank map, not a 401 — a legible map
+  wearing a watermark. The key is free, issued by return email with no queue and
+  no Carto account, and covers 5 million tile requests a month.
+
+  Carto also say the raster service is being retired in favour of vector tiles
+  and that they are considering freezing its data updates, with no date
+  published for either. Rover's basemap layer is raster-only today; the key
+  covers both services, so nothing is wasted when that changes.
+
+  Thanks to [@rockneurotiko](https://github.com/rockneurotiko), who found this
+  and wrote the implementation.
+
 - **Dialyzer in CI**, and `mix dialyzer` locally. The public API is annotated
   with `@spec` end to end and nothing ever checked those annotations against the
   code. The PLT is written to `_build/plts`, so the `_build` cache CI already
@@ -85,11 +93,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in `mix.exs`, and the lint row of the CI matrix runs it. The floor is a
   ratchet: raise it when a release lands above it, never lower it to make a red
   run green.
-
 ### Removed
 
 - A `Rover.Shape` fallback clause that could not be reached — every caller of the
   private `get/2` is already inside an `is_map/1` guard. Dialyzer's first find.
+
 ## [0.4.0] - 2026-08-12
 
 ### Added
@@ -409,7 +417,6 @@ them.
   back as strings and will not match.
 - `fit` governs *re*fitting; the initial framing is separate.
 
-[0.6.0]: https://github.com/nseaSeb/rover/releases/tag/v0.6.0
 [0.5.0]: https://github.com/nseaSeb/rover/releases/tag/v0.5.0
 [0.4.0]: https://github.com/nseaSeb/rover/releases/tag/v0.4.0
 [0.3.2]: https://github.com/nseaSeb/rover/releases/tag/v0.3.2

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -36,6 +36,7 @@ The OpenStreetMap and CARTO presets target public demo endpoints whose usage
 policies forbid production traffic. For anything real, pass `{:xyz, url}` with
 tiles you are entitled to serve.
 
-CARTO also requires an API key on its raster presets (`:carto_light`,
-`:carto_dark`, `:carto_voyager`) and is retiring those raster endpoints in
-favor of vector tiles. See `Rover.Tiles` for how to configure a key.
+CARTO's basemaps (`:carto_light`, `:carto_dark`, `:carto_voyager`) now need a
+free API key; without one the tiles arrive watermarked. CARTO's terms also
+require that its attribution, and OpenStreetMap's, stay visible — Rover renders
+both. See `Rover.Tiles` for how to configure a key.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ is somewhere else entirely.
 
 ```elixir
 def deps do
-  [{:rover, "~> 0.6"}]
+  [{:rover, "~> 0.5"}]
 end
 ```
 
@@ -458,8 +458,13 @@ The OSM and Carto presets point at **public demo servers with usage policies
 that forbid production traffic** — for anything real, point `{:xyz, …}` at tiles
 you are entitled to use.
 
-Carto now requires an API key on `:carto_light`, `:carto_dark`, and
-`:carto_voyager`:
+**Carto's basemaps now need an API key.** Without one the tiles still load —
+they are served with `API KEY REQUIRED` stamped diagonally across every one, so
+the symptom is a legible map wearing a watermark rather than a blank map or an
+error in the console. The key is free, issued by return email with no queue and
+no Carto account, and covers 5 million tile requests a month across their raster
+and vector services. Attribution must stay visible, which Rover renders for you.
+Request one at <https://carto.com/basemaps/apikey/>, then:
 
 ```elixir
 # config.exs — applies to every carto_* preset
@@ -471,9 +476,11 @@ config :rover, Rover.Tiles, carto_api_key: "YOUR_KEY"
 <.map id="m" tiles={{:carto_dark, key: "YOUR_KEY"}} ... />
 ```
 
-Carto is also retiring these raster endpoints for vector tiles; Rover's
-OpenLayers basemap layer is raster-only today, so treat the Carto presets as a
-transitional option rather than a long-term one.
+Carto also says the raster (PNG) service is being retired in favour of vector
+tiles, and that they are considering freezing its data updates. No date is
+published. Rover's OpenLayers basemap layer is raster-only today, so treat the
+Carto presets as a transitional option rather than a long-term one — the key you
+request now covers the vector service too, whenever Rover reaches it.
 
 ## What "only update what changed" actually means
 

--- a/lib/rover.ex
+++ b/lib/rover.ex
@@ -27,7 +27,7 @@ defmodule Rover do
   Add the dependency:
 
       def deps do
-        [{:rover, "~> 0.6"}]
+        [{:rover, "~> 0.5"}]
       end
 
   Register the hook in `assets/js/app.js`. Rover ships a prebuilt bundle with

--- a/lib/rover/tiles.ex
+++ b/lib/rover/tiles.ex
@@ -17,9 +17,19 @@ defmodule Rover.Tiles do
 
   ## Carto API keys
 
-  Carto now requires an API key on `:carto_light`, `:carto_dark`, and
-  `:carto_voyager`, requests without one are rejected. Configure a default for
-  the whole app:
+  Carto's basemaps now need an API key. Without one the tiles still load — they
+  arrive with `API KEY REQUIRED` stamped diagonally across every one, so the
+  symptom is a legible map wearing a watermark rather than a blank map or an
+  error in the console. That is worth knowing before you go looking for a 401
+  that never comes.
+
+  The key is free: Carto issue it by return email, with no approval queue and no
+  Carto account, and it covers 5 million tile requests a month across their
+  raster and vector services. Their terms require the CARTO and OpenStreetMap
+  attribution to stay visible, which Rover renders for you. Request one at
+  <https://carto.com/basemaps/apikey/>.
+
+  Configure a default for the whole app:
 
       config :rover, Rover.Tiles, carto_api_key: "YOUR_KEY"
 
@@ -27,12 +37,13 @@ defmodule Rover.Tiles do
 
       <.map id="m" tiles={{:carto_dark, key: "YOUR_KEY"}} ... />
 
-  Carto is also retiring these raster tile endpoints in favor of vector tiles
-  (MapLibre-style GL JSON served as MVT). Rover's map renders basemaps through
-  OpenLayers' raster `XYZ` source today, so the presets here stay on raster
-  until Rover grows a vector tile layer — track Carto's deprecation notices if
-  you depend on `:carto_light`, `:carto_dark`, or `:carto_voyager` past their
-  raster sunset date.
+  Carto also say the raster (PNG) service is being retired in favour of vector
+  tiles, and that they are considering freezing its data updates — the
+  cartography would stay where it is while vector keeps moving. No date is
+  published for either. Rover's map renders basemaps through OpenLayers' raster
+  `XYZ` source today, so the presets here stay on raster until Rover grows a
+  vector tile layer; the key you request now covers both services, so nothing is
+  wasted when it does.
 
   ## France
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rover.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.5.0"
   @source_url "https://github.com/nseaSeb/rover"
 
   def project do


### PR DESCRIPTION
Two release commits were cut within an hour of each other this morning: `Rover 0.5.0`, then `Rover 0.6.0` for the Carto support that landed after it. **Neither was ever published to Hex.** This folds them into one release, and corrects the Carto documentation against the primary source.

## One release

Publishing both would mean two consecutive versions on Hex an hour apart, the first of which nobody has a reason to install. Skipping 0.5.0 would leave a changelog section for a version nobody *can* install. So: one `0.5.0`, containing drawing, the accessibility pass, Dialyzer, the coverage floor, and Carto keys. Hex goes 0.4.0 → 0.5.0, no gap, one publish.

The tags `v0.5.0` and `v0.6.0` are deleted with this merge — never published, an hour old, and no branch history is rewritten.

## What Carto's key requirement actually does

#17 said, and this repository then published in a tag: *"requests without one are rejected"*. That is not what happens.

The tiles are served — HTTP 200, valid PNG — with `API KEY REQUIRED` stamped diagonally across every one. Verified by fetching the exact URL `Rover.Tiles` builds and **looking at the image**, not at the status code. Reading a 200 as proof the presets still worked was this repository's own earlier mistake, in the opposite direction.

The difference is the part a user acts on: the symptom is a legible map wearing a watermark. Anyone told to expect a rejection goes looking for a 401 or a blank map and finds neither.

Added from <https://carto.com/basemaps/apikey/>, none of it previously in the docs and all of it needed before deciding:

- The key is **free**, issued by return email, no approval queue, no Carto account.
- **5 million tile requests a month**, counted across the raster and vector services.
- CARTO and OpenStreetMap attribution must stay visible. `@carto_attribution` already carries both — Rover is compliant as it stands, verified.

The retirement note is kept: the source does say raster "is being retired" and that they are considering freezing its data updates. The invented part is removed — there is no published sunset date to track.

## Verification

`mix format --check-formatted`, `deps.unlock --check-unused`, `compile --warnings-as-errors`, 31 doctests + 211 tests, 103 Node tests, 28 browser scenarios, `mix dialyzer` 0 errors, coverage 95.85% against the 95% floor, `priv/static` in sync, `mix docs` clean, and `mix hex.build` producing the 0.5.0 tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UexYXBcqg5F5JaQAJ9HhjY